### PR TITLE
Broken i18n fallbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
 # master
 
-# 4.4.1
+# 4.4.2
 
 - Use compiled regex for performance improvement (#2502)
+
+# 4.4.1
+
+- Yanked
 
 # 4.4.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # master
 
+# 4.4.1
+
+- Use compiled regex for performance improvement (#2502)
+
 # 4.4.0
 
 - Ruby 3.0 support.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,13 +1,13 @@
 PATH
   remote: middleman-cli
   specs:
-    middleman-cli (4.4.0)
+    middleman-cli (4.4.2)
       thor (>= 0.17.0, < 2.0)
 
 PATH
   remote: middleman-core
   specs:
-    middleman-core (4.4.0)
+    middleman-core (4.4.2)
       activesupport (>= 6.1, < 7.0)
       addressable (~> 2.4)
       backports (~> 3.6)
@@ -36,13 +36,13 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (6.1.3.2)
+    activesupport (6.1.4.1)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
       tzinfo (~> 2.0)
       zeitwerk (~> 2.3)
-    addressable (2.7.0)
+    addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
     aruba (0.7.4)
       childprocess (>= 0.3.6)
@@ -93,9 +93,9 @@ GEM
     dotenv (2.7.6)
     erubis (2.7.0)
     execjs (2.8.1)
-    fast_blank (1.0.0)
-    fastimage (2.2.4)
-    ffi (1.15.1)
+    fast_blank (1.0.1)
+    fastimage (2.2.5)
+    ffi (1.15.4)
     gherkin (4.1.3)
     haml (4.0.7)
       tilt
@@ -224,7 +224,7 @@ GEM
     xpath (2.1.0)
       nokogiri (~> 1.3)
     yard (0.9.26)
-    zeitwerk (2.4.2)
+    zeitwerk (2.5.1)
 
 PLATFORMS
   ruby
@@ -255,4 +255,4 @@ DEPENDENCIES
   yard (~> 0.9.20)
 
 BUNDLED WITH
-   2.2.20
+   2.2.22

--- a/middleman-core/features/i18n_preview.feature
+++ b/middleman-core/features/i18n_preview.feature
@@ -1,241 +1,241 @@
-# Feature: i18n Preview
-#   In order to preview localized html
+Feature: i18n Preview
+  In order to preview localized html
 
-#   Scenario: Running localize with the default config
-#     Given a fixture app "i18n-test-app"
-#     And a file named "config.rb" with:
-#       """
-#       activate :i18n
-#       """
-#     Given the Server is running at "i18n-test-app"
-#     When I go to "/"
-#     Then I should see "Howdy"
-#     When I go to "/hello.html"
-#     Then I should see "Hello World"
-#     When I go to "/morning.html"
-#     Then I should see "Good morning"
-#     When I go to "/one.html"
-#     Then I should see "Only one"
-#     When I go to "/defaults_en/index.html"
-#     Then I should see "File Not Found"
-#     When I go to "/en/index.html"
-#     Then I should see "File Not Found"
-#     When I go to "/en/morning.html"
-#     Then I should see "File Not Found"
-#     When I go to "/defaults_es/index.html"
-#     Then I should see "File Not Found"
-#     When I go to "/es/index.html"
-#     Then I should see "Como Esta?"
-#     When I go to "/es/hola.html"
-#     Then I should see "Hola World"
-#     When I go to "/es/manana.html"
-#     Then I should see "Buenos días"
-#     When I go to "/es/una.html"
-#     Then I should see "Solamente una"
+  Scenario: Running localize with the default config
+    Given a fixture app "i18n-test-app"
+    And a file named "config.rb" with:
+      """
+      activate :i18n
+      """
+    Given the Server is running at "i18n-test-app"
+    When I go to "/"
+    Then I should see "Howdy"
+    When I go to "/hello.html"
+    Then I should see "Hello World"
+    When I go to "/morning.html"
+    Then I should see "Good morning"
+    When I go to "/one.html"
+    Then I should see "Only one"
+    When I go to "/defaults_en/index.html"
+    Then I should see "File Not Found"
+    When I go to "/en/index.html"
+    Then I should see "File Not Found"
+    When I go to "/en/morning.html"
+    Then I should see "File Not Found"
+    When I go to "/defaults_es/index.html"
+    Then I should see "File Not Found"
+    When I go to "/es/index.html"
+    Then I should see "Como Esta?"
+    When I go to "/es/hola.html"
+    Then I should see "Hola World"
+    When I go to "/es/manana.html"
+    Then I should see "Buenos días"
+    When I go to "/es/una.html"
+    Then I should see "Solamente una"
 
-#   Scenario: A template changes i18n during preview
-#     Given a fixture app "i18n-test-app"
-#     And a file named "config.rb" with:
-#       """
-#       activate :i18n
-#       """
-#     Given the Server is running at "i18n-test-app"
-#     And the file "locales/en.yml" has the contents
-#       """
-#       ---
-#       en:
-#         greetings: "Howdy"
-#         hi: "Hello"
-#       """
-#     When I go to "/"
-#     Then I should see "Howdy"
-#     When I go to "/hello.html"
-#     Then I should see "Hello World"
-#     When the file "locales/en.yml" has the contents
-#       """
-#       ---
-#       en:
-#         greetings: "How You Doin"
-#         hi: "Sup"
-#       """
-#     When I go to "/"
-#     Then I should see "How You Doin"
-#     When I go to "/hello.html"
-#     Then I should see "Sup World"
+  Scenario: A template changes i18n during preview
+    Given a fixture app "i18n-test-app"
+    And a file named "config.rb" with:
+      """
+      activate :i18n
+      """
+    Given the Server is running at "i18n-test-app"
+    And the file "locales/en.yml" has the contents
+      """
+      ---
+      en:
+        greetings: "Howdy"
+        hi: "Hello"
+      """
+    When I go to "/"
+    Then I should see "Howdy"
+    When I go to "/hello.html"
+    Then I should see "Hello World"
+    When the file "locales/en.yml" has the contents
+      """
+      ---
+      en:
+        greetings: "How You Doin"
+        hi: "Sup"
+      """
+    When I go to "/"
+    Then I should see "How You Doin"
+    When I go to "/hello.html"
+    Then I should see "Sup World"
 
-#   Scenario: Running localize with the alt path config
-#     Given a fixture app "i18n-test-app"
-#     And a file named "config.rb" with:
-#       """
-#       activate :i18n, path: "/lang_:locale/"
-#       """
-#     Given the Server is running at "i18n-test-app"
-#     When I go to "/"
-#     Then I should see "Howdy"
-#     When I go to "/hello.html"
-#     Then I should see "Hello World"
-#     When I go to "/lang_en/index.html"
-#     Then I should see "File Not Found"
-#     When I go to "/lang_es/index.html"
-#     Then I should see "Como Esta?"
-#     When I go to "/lang_es/hola.html"
-#     Then I should see "Hola World"
-
-
-#   Scenario: Running localize with the alt root config
-#     Given a fixture app "i18n-alt-root-app"
-#     And a file named "config.rb" with:
-#       """
-#       activate :i18n, templates_dir: "lang_data"
-#       """
-#     Given the Server is running at "i18n-alt-root-app"
-#     When I go to "/"
-#     Then I should see "Howdy"
-#     When I go to "/hello.html"
-#     Then I should see "Hello World"
-#     When I go to "/en/index.html"
-#     Then I should see "File Not Found"
-#     When I go to "/es/index.html"
-#     Then I should see "Como Esta?"
-#     When I go to "/es/hola.html"
-#     Then I should see "Hola World"
-
-#   Scenario: Running localize with the lang map config
-#     Given a fixture app "i18n-test-app"
-#     And a file named "config.rb" with:
-#       """
-#       activate :i18n, lang_map: { en: :english, es: :spanish }
-#       """
-#     Given the Server is running at "i18n-test-app"
-#     When I go to "/"
-#     Then I should see "Howdy"
-#     When I go to "/hello.html"
-#     Then I should see "Hello World"
-#     When I go to "/english/index.html"
-#     Then I should see "File Not Found"
-#     When I go to "/spanish/index.html"
-#     Then I should see "Como Esta?"
-#     When I go to "/spanish/hola.html"
-#     Then I should see "Hola World"
-
-#   Scenario: Running localize with a non-English mount config
-#     Given a fixture app "i18n-test-app"
-#     And a file named "config.rb" with:
-#       """
-#       activate :i18n, mount_at_root: :es
-#       """
-#     Given the Server is running at "i18n-test-app"
-#     When I go to "/en/index.html"
-#     Then I should see "Howdy"
-#     When I go to "/en/hello.html"
-#     Then I should see "Hello World"
-#     When I go to "/"
-#     Then I should see "Como Esta?"
-#     When I go to "/hola.html"
-#     Then I should see "Hola World"
-#     When I go to "/manana.html"
-#     Then I should see "Buenos días"
-#     When I go to "/hello.html"
-#     Then I should see "File Not Found"
-#     When I go to "/en/morning.html"
-#     Then I should see "Good morning"
-#     When I go to "/es/manana.html"
-#     Then I should see "File Not Found"
-#     When I go to "/es/index.html"
-#     Then I should see "File Not Found"
-#     When I go to "/es/hola.html"
-#     Then I should see "File Not Found"
-
-#   Scenario: Running localize with a non-English lang subset
-#     Given a fixture app "i18n-test-app"
-#     And a file named "config.rb" with:
-#       """
-#       activate :i18n, langs: :es
-#       """
-#     Given the Server is running at "i18n-test-app"
-#     When I go to "/en/index.html"
-#     Then I should see "File Not Found"
-#     When I go to "/en/hello.html"
-#     Then I should see "File Not Found"
-#     When I go to "/"
-#     Then I should see "Como Esta?"
-#     When I go to "/hola.html"
-#     Then I should see "Hola World"
-#     When I go to "/hello.html"
-#     Then I should see "File Not Found"
-#     When I go to "/es/index.html"
-#     Then I should see "File Not Found"
-#     When I go to "/es/hola.html"
-#     Then I should see "File Not Found"
+  Scenario: Running localize with the alt path config
+    Given a fixture app "i18n-test-app"
+    And a file named "config.rb" with:
+      """
+      activate :i18n, path: "/lang_:locale/"
+      """
+    Given the Server is running at "i18n-test-app"
+    When I go to "/"
+    Then I should see "Howdy"
+    When I go to "/hello.html"
+    Then I should see "Hello World"
+    When I go to "/lang_en/index.html"
+    Then I should see "File Not Found"
+    When I go to "/lang_es/index.html"
+    Then I should see "Como Esta?"
+    When I go to "/lang_es/hola.html"
+    Then I should see "Hola World"
 
 
-#   Scenario: Running localize with the no mount config
-#     Given a fixture app "i18n-test-app"
-#     And a file named "config.rb" with:
-#       """
-#       activate :i18n, mount_at_root: false
-#       """
-#     Given the Server is running at "i18n-test-app"
-#     When I go to "/en/index.html"
-#     Then I should see "Howdy"
-#     When I go to "/en/hello.html"
-#     Then I should see "Hello World"
-#     When I go to "/"
-#     Then I should see "File Not Found"
-#     When I go to "/hello.html"
-#     Then I should see "File Not Found"
-#     When I go to "/es/index.html"
-#     Then I should see "Como Esta?"
-#     When I go to "/es/hola.html"
-#     Then I should see "Hola World"
+  Scenario: Running localize with the alt root config
+    Given a fixture app "i18n-alt-root-app"
+    And a file named "config.rb" with:
+      """
+      activate :i18n, templates_dir: "lang_data"
+      """
+    Given the Server is running at "i18n-alt-root-app"
+    When I go to "/"
+    Then I should see "Howdy"
+    When I go to "/hello.html"
+    Then I should see "Hello World"
+    When I go to "/en/index.html"
+    Then I should see "File Not Found"
+    When I go to "/es/index.html"
+    Then I should see "Como Esta?"
+    When I go to "/es/hola.html"
+    Then I should see "Hola World"
 
-#   Scenario: Running localize with the subset config
-#     Given a fixture app "i18n-test-app"
-#     And a file named "config.rb" with:
-#       """
-#       activate :i18n, langs: [:en]
-#       """
-#     Given the Server is running at "i18n-test-app"
-#     When I go to "/"
-#     Then I should see "Howdy"
-#     When I go to "/hello.html"
-#     Then I should see "Hello World"
-#     When I go to "/en/index.html"
-#     Then I should see "File Not Found"
-#     When I go to "/es/index.html"
-#     Then I should see "File Not Found"
-#     When I go to "/es/hola.html"
-#     Then I should see "File Not Found"
+  Scenario: Running localize with the lang map config
+    Given a fixture app "i18n-test-app"
+    And a file named "config.rb" with:
+      """
+      activate :i18n, lang_map: { en: :english, es: :spanish }
+      """
+    Given the Server is running at "i18n-test-app"
+    When I go to "/"
+    Then I should see "Howdy"
+    When I go to "/hello.html"
+    Then I should see "Hello World"
+    When I go to "/english/index.html"
+    Then I should see "File Not Found"
+    When I go to "/spanish/index.html"
+    Then I should see "Como Esta?"
+    When I go to "/spanish/hola.html"
+    Then I should see "Hola World"
 
-#   Scenario: Running localize with relative_assets
-#     Given a fixture app "i18n-test-app"
-#     And a file named "config.rb" with:
-#       """
-#       activate :i18n
-#       activate :relative_assets
-#       """
-#     Given the Server is running at "i18n-test-app"
-#     When I go to "/"
-#     Then I should see '"stylesheets/site.css"'
-#     When I go to "/hello.html"
-#     Then I should see '"stylesheets/site.css"'
-#     When I go to "/es/index.html"
-#     Then I should see '"../stylesheets/site.css"'
-#     When I go to "/es/hola.html"
-#     Then I should see '"../stylesheets/site.css"'
+  Scenario: Running localize with a non-English mount config
+    Given a fixture app "i18n-test-app"
+    And a file named "config.rb" with:
+      """
+      activate :i18n, mount_at_root: :es
+      """
+    Given the Server is running at "i18n-test-app"
+    When I go to "/en/index.html"
+    Then I should see "Howdy"
+    When I go to "/en/hello.html"
+    Then I should see "Hello World"
+    When I go to "/"
+    Then I should see "Como Esta?"
+    When I go to "/hola.html"
+    Then I should see "Hola World"
+    When I go to "/manana.html"
+    Then I should see "Buenos días"
+    When I go to "/hello.html"
+    Then I should see "File Not Found"
+    When I go to "/en/morning.html"
+    Then I should see "Good morning"
+    When I go to "/es/manana.html"
+    Then I should see "File Not Found"
+    When I go to "/es/index.html"
+    Then I should see "File Not Found"
+    When I go to "/es/hola.html"
+    Then I should see "File Not Found"
 
-#   Scenario: Missing translations fall back to the default locale
-#     Given a fixture app "i18n-default-app"
-#     And a file named "config.rb" with:
-#       """
-#       activate :i18n, mount_at_root: :es
-#       """
-#     Given the Server is running at "i18n-default-app"
-#     When I go to "/en/"
-#     Then I should see "Default locale: es"
-#     Then I should see "Current locale: en"
-#     Then I should see "Buenos días"
-#     Then I should see "Howdy"
+  Scenario: Running localize with a non-English lang subset
+    Given a fixture app "i18n-test-app"
+    And a file named "config.rb" with:
+      """
+      activate :i18n, langs: :es
+      """
+    Given the Server is running at "i18n-test-app"
+    When I go to "/en/index.html"
+    Then I should see "File Not Found"
+    When I go to "/en/hello.html"
+    Then I should see "File Not Found"
+    When I go to "/"
+    Then I should see "Como Esta?"
+    When I go to "/hola.html"
+    Then I should see "Hola World"
+    When I go to "/hello.html"
+    Then I should see "File Not Found"
+    When I go to "/es/index.html"
+    Then I should see "File Not Found"
+    When I go to "/es/hola.html"
+    Then I should see "File Not Found"
+
+
+  Scenario: Running localize with the no mount config
+    Given a fixture app "i18n-test-app"
+    And a file named "config.rb" with:
+      """
+      activate :i18n, mount_at_root: false
+      """
+    Given the Server is running at "i18n-test-app"
+    When I go to "/en/index.html"
+    Then I should see "Howdy"
+    When I go to "/en/hello.html"
+    Then I should see "Hello World"
+    When I go to "/"
+    Then I should see "File Not Found"
+    When I go to "/hello.html"
+    Then I should see "File Not Found"
+    When I go to "/es/index.html"
+    Then I should see "Como Esta?"
+    When I go to "/es/hola.html"
+    Then I should see "Hola World"
+
+  Scenario: Running localize with the subset config
+    Given a fixture app "i18n-test-app"
+    And a file named "config.rb" with:
+      """
+      activate :i18n, langs: [:en]
+      """
+    Given the Server is running at "i18n-test-app"
+    When I go to "/"
+    Then I should see "Howdy"
+    When I go to "/hello.html"
+    Then I should see "Hello World"
+    When I go to "/en/index.html"
+    Then I should see "File Not Found"
+    When I go to "/es/index.html"
+    Then I should see "File Not Found"
+    When I go to "/es/hola.html"
+    Then I should see "File Not Found"
+
+  Scenario: Running localize with relative_assets
+    Given a fixture app "i18n-test-app"
+    And a file named "config.rb" with:
+      """
+      activate :i18n
+      activate :relative_assets
+      """
+    Given the Server is running at "i18n-test-app"
+    When I go to "/"
+    Then I should see '"stylesheets/site.css"'
+    When I go to "/hello.html"
+    Then I should see '"stylesheets/site.css"'
+    When I go to "/es/index.html"
+    Then I should see '"../stylesheets/site.css"'
+    When I go to "/es/hola.html"
+    Then I should see '"../stylesheets/site.css"'
+
+  Scenario: Missing translations fall back to the default locale
+    Given a fixture app "i18n-default-app"
+    And a file named "config.rb" with:
+      """
+      activate :i18n, mount_at_root: :es
+      """
+    Given the Server is running at "i18n-default-app"
+    When I go to "/en/"
+    Then I should see "Default locale: es"
+    Then I should see "Current locale: en"
+    Then I should see "Buenos días"
+    Then I should see "Howdy"
 
 #   Scenario: Nested i18n yaml
 #     Given a fixture app "i18n-nested-app"

--- a/middleman-core/lib/middleman-core/core_extensions/i18n.rb
+++ b/middleman-core/lib/middleman-core/core_extensions/i18n.rb
@@ -235,7 +235,9 @@ class Middleman::CoreExtensions::Internationalization < ::Middleman::Extension
     ::I18n.default_locale = @mount_at_root
 
     # Reset fallbacks to fall back to our new default
-    ::I18n.fallbacks = ::I18n::Locale::Fallbacks.new if ::I18n.respond_to?(:fallbacks)
+    if ::I18n.respond_to?(:fallbacks)
+      ::I18n.fallbacks = ::I18n::Locale::Fallbacks.new(@mount_at_root)
+    end
   end
 
   Contract ArrayOf[Symbol]

--- a/middleman-core/lib/middleman-core/version.rb
+++ b/middleman-core/lib/middleman-core/version.rb
@@ -1,5 +1,5 @@
 module Middleman
   # Current Version
   # @return [String]
-  VERSION = '4.4.1'.freeze unless const_defined?(:VERSION)
+  VERSION = '4.4.2'.freeze unless const_defined?(:VERSION)
 end

--- a/middleman-core/lib/middleman-core/version.rb
+++ b/middleman-core/lib/middleman-core/version.rb
@@ -1,5 +1,5 @@
 module Middleman
   # Current Version
   # @return [String]
-  VERSION = '4.4.0'.freeze unless const_defined?(:VERSION)
+  VERSION = '4.4.1'.freeze unless const_defined?(:VERSION)
 end


### PR DESCRIPTION
I recently noticed that I18n fallbacks looked to be dysfunctional on one of my middleman (4.4.0) websites.
After digging a bit, I think it may be because of a breaking change in the ruby-i18n gem (see https://github.com/ruby-i18n/i18n/pull/415).

I have uncommented some tests (cucumber features) that seem to be actually passing, and which contain one feature that does verify that I18n fallbacks are functional. That feature is indeed fixed by this PR.